### PR TITLE
Add AI platform architecture documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # AI Platform
 
-Documentation for an AI Platform that exposes AI capabilities through a web interface and a language model gateway. See [docs/architecture.md](docs/architecture.md) for details.
+Documentation for an AI Platform that exposes AI capabilities through a web interface, an OIDC identity provider for user authentication, and a language model gateway. See [docs/architecture.md](docs/architecture.md) for details.
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
-# ai-platform
+# AI Platform
+
+Documentation for an AI Platform that exposes AI capabilities through a web interface and a language model gateway. See [docs/architecture.md](docs/architecture.md) for details.
+

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,48 @@
+# AI Platform Architecture
+
+This document describes an AI Platform that exposes AI capabilities through a web interface and a gateway that abstracts external language models.
+
+## Components
+
+- **WebGUI**: User-facing interface built on OpenWebUI.
+- **LLM Gateway**: Abstraction layer based on LiteLLM that routes requests to different model providers.
+- **External Providers**: Managed or self-hosted large language models such as OpenAI, Anthropic, Gemini, or on-premise models like Mistral.
+
+## Context Diagram
+
+```mermaid
+%%{init: { 'theme': 'neutral' } }%%
+C4Context
+    title AI Platform Context
+    Person(user, "User", "Interacts with the platform")
+    System_Boundary(platform, "AI Platform") {
+        System(webgui, "WebGUI", "OpenWebUI interface")
+        System(gateway, "LLM Gateway", "LiteLLM abstraction layer")
+    }
+    System_Ext(openai, "OpenAI", "External LLM provider")
+    System_Ext(anthropic, "Anthropic", "External LLM provider")
+    System_Ext(mistral, "Mistral", "On-prem LLM")
+    Rel(user, webgui, "Uses")
+    Rel(webgui, gateway, "Sends prompts")
+    Rel(gateway, openai, "Forwards requests")
+    Rel(gateway, anthropic, "Forwards requests")
+    Rel(gateway, mistral, "Forwards requests")
+```
+
+## Interaction Sequence
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant W as WebGUI
+    participant G as LLM Gateway
+    participant P as LLM Provider
+    U->>W: Submit prompt
+    W->>G: Forward prompt
+    G->>P: Request completion
+    P-->>G: Return response
+    G-->>W: Send response
+    W-->>U: Display answer
+```
+
+

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,10 +1,11 @@
 # AI Platform Architecture
 
-This document describes an AI Platform that exposes AI capabilities through a web interface and a gateway that abstracts external language models.
+This document describes an AI Platform that exposes AI capabilities through a web interface, authenticates users via an OIDC provider, and routes requests through a gateway that abstracts external language models.
 
 ## Components
 
 - **WebGUI**: User-facing interface built on OpenWebUI.
+- **Identity Provider**: OIDC-compliant service (e.g., Microsoft Entra ID) that authenticates users for the WebGUI.
 - **LLM Gateway**: Abstraction layer based on LiteLLM that routes requests to different model providers.
 - **External Providers**: Managed or self-hosted large language models such as OpenAI, Anthropic, Gemini, or on-premise models like Mistral.
 
@@ -19,10 +20,12 @@ C4Context
         System(webgui, "WebGUI", "OpenWebUI interface")
         System(gateway, "LLM Gateway", "LiteLLM abstraction layer")
     }
+    System_Ext(oidc, "OIDC Provider", "Microsoft Entra ID")
     System_Ext(openai, "OpenAI", "External LLM provider")
     System_Ext(anthropic, "Anthropic", "External LLM provider")
     System_Ext(mistral, "Mistral", "On-prem LLM")
     Rel(user, webgui, "Uses")
+    Rel(webgui, oidc, "Authenticates users")
     Rel(webgui, gateway, "Sends prompts")
     Rel(gateway, openai, "Forwards requests")
     Rel(gateway, anthropic, "Forwards requests")
@@ -35,8 +38,13 @@ C4Context
 sequenceDiagram
     participant U as User
     participant W as WebGUI
+    participant I as OIDC Provider
     participant G as LLM Gateway
     participant P as LLM Provider
+    U->>W: Access platform
+    W->>I: Redirect to login
+    U->>I: Authenticate
+    I-->>W: Return token
     U->>W: Submit prompt
     W->>G: Forward prompt
     G->>P: Request completion

--- a/docs/diagrams/context.mmd
+++ b/docs/diagrams/context.mmd
@@ -1,0 +1,16 @@
+%%{init: { 'theme': 'neutral' } }%%
+C4Context
+    title AI Platform Context
+    Person(user, "User", "Interacts with the platform")
+    System_Boundary(platform, "AI Platform") {
+        System(webgui, "WebGUI", "OpenWebUI interface")
+        System(gateway, "LLM Gateway", "LiteLLM abstraction layer")
+    }
+    System_Ext(openai, "OpenAI", "External LLM provider")
+    System_Ext(anthropic, "Anthropic", "External LLM provider")
+    System_Ext(mistral, "Mistral", "On-prem LLM")
+    Rel(user, webgui, "Uses")
+    Rel(webgui, gateway, "Sends prompts")
+    Rel(gateway, openai, "Forwards requests")
+    Rel(gateway, anthropic, "Forwards requests")
+    Rel(gateway, mistral, "Forwards requests")

--- a/docs/diagrams/context.mmd
+++ b/docs/diagrams/context.mmd
@@ -6,10 +6,12 @@ C4Context
         System(webgui, "WebGUI", "OpenWebUI interface")
         System(gateway, "LLM Gateway", "LiteLLM abstraction layer")
     }
+    System_Ext(oidc, "OIDC Provider", "Microsoft Entra ID")
     System_Ext(openai, "OpenAI", "External LLM provider")
     System_Ext(anthropic, "Anthropic", "External LLM provider")
     System_Ext(mistral, "Mistral", "On-prem LLM")
     Rel(user, webgui, "Uses")
+    Rel(webgui, oidc, "Authenticates users")
     Rel(webgui, gateway, "Sends prompts")
     Rel(gateway, openai, "Forwards requests")
     Rel(gateway, anthropic, "Forwards requests")

--- a/docs/diagrams/interaction.mmd
+++ b/docs/diagrams/interaction.mmd
@@ -1,8 +1,13 @@
 sequenceDiagram
     participant U as User
     participant W as WebGUI
+    participant I as OIDC Provider
     participant G as LLM Gateway
     participant P as LLM Provider
+    U->>W: Access platform
+    W->>I: Redirect to login
+    U->>I: Authenticate
+    I-->>W: Return token
     U->>W: Submit prompt
     W->>G: Forward prompt
     G->>P: Request completion

--- a/docs/diagrams/interaction.mmd
+++ b/docs/diagrams/interaction.mmd
@@ -1,0 +1,11 @@
+sequenceDiagram
+    participant U as User
+    participant W as WebGUI
+    participant G as LLM Gateway
+    participant P as LLM Provider
+    U->>W: Submit prompt
+    W->>G: Forward prompt
+    G->>P: Request completion
+    P-->>G: Return response
+    G-->>W: Send response
+    W-->>U: Display answer


### PR DESCRIPTION
## Summary
- document AI Platform components and context
- add sequence and architecture diagrams using Mermaid

## Testing
- `mmdc -p puppeteer-config.json -i docs/diagrams/context.mmd -o /tmp/context.svg`
- `mmdc -p puppeteer-config.json -i docs/diagrams/interaction.mmd -o /tmp/interaction.svg`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_688c83f2c5b483328043ef36554861d7