### PR TITLE
Align diagrams with architecture

### DIFF
--- a/docs/diagrams/openwebui.mmd
+++ b/docs/diagrams/openwebui.mmd
@@ -1,10 +1,21 @@
 %%{init: { 'theme': 'neutral' } }%%
 C4Container
     title OpenWebUI Detail
+
+    UpdateLayoutConfig("3", "1")
+
     Person(user, "User", "Interacts with the UI")
-    Container(web, "OpenWebUI", "Python", "Main web application")
-    ContainerDb(db, "Database", "PostgreSQL", "Stores configuration and chat history")
-    System_Ext(litellm, "LiteLLM", "LLM gateway")
+
+    System_Boundary(owui, "OpenWebUI") {
+        Container(web, "OpenWebUI", "Python", "Main web application")
+        ContainerDb(db, "Database", "PostgreSQL", "Stores configuration and chat history")
+    }
+
+    System_Boundary(llmGateway, "LLM Gateway") {
+        Container(gateway, "LiteLLM", "Python", "LLM Gateway")
+    }
+
     Rel(user, web, "Uses")
     Rel(web, db, "Reads and writes", "SQL")
-    Rel(web, litellm, "Sends prompts", "HTTP")
+    Rel(web, gateway, "Sends prompts", "HTTP")
+


### PR DESCRIPTION
## Summary
- Align OpenWebUI Mermaid diagram with Architecture.md
- Validate all diagrams with Mermaid CLI

## Testing
- `mmdc -p /tmp/puppeteer-config.json -i docs/diagrams/context.mmd -o /tmp/context.svg`
- `mmdc -p /tmp/puppeteer-config.json -i docs/diagrams/interaction.mmd -o /tmp/interaction.svg`
- `mmdc -p /tmp/puppeteer-config.json -i docs/diagrams/openwebui.mmd -o /tmp/openwebui.svg`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6895be631b388332b17badc66b47bb57